### PR TITLE
Update en_exclude.txt

### DIFF
--- a/scripts/data/en_exclude.txt
+++ b/scripts/data/en_exclude.txt
@@ -1,4 +1,13 @@
 ab'ut
+thisa
+thisfor
+thisis
+thisisit
+thisismy
+thisjob
+thisjust
+thisl
+thiss
 tobelieve
 tofind
 togethe


### PR DESCRIPTION
Removed words that aren't English:
"thisa": 59,
"thisfor": 63,
"thisis": 779,
"thisisit": 92,
"thisismy": 89,
"thisjob": 52,
"thisjust": 67,
"thisl": 61,
"thiss": 79,